### PR TITLE
Fixed null bug when schedule is updated by server, it would leave the…

### DIFF
--- a/AzSphereThermostat/main.c
+++ b/AzSphereThermostat/main.c
@@ -216,7 +216,7 @@ static void ScheduleServerCheckEventHandler(EventData *eventData) {
 	if (ConsumeTimerFdEvent(schedulePollTimerFd) != 0) {
 		return;
 	}
-	checkServerForScheduleUpdates();
+	checkServerForScheduleUpdates(userSettings_ptr);
 }
 
 // event handler data structures. Only the event handler field needs to be populated.

--- a/AzSphereThermostat/schedule.h
+++ b/AzSphereThermostat/schedule.h
@@ -20,4 +20,4 @@ bool cycleExpired(struct thermostatSettings *userSettings_ptr);
 /// </summary>
 void initCycle(struct thermostatSettings *userSettings_ptr);
 
-bool checkServerForScheduleUpdates();
+bool checkServerForScheduleUpdates(struct thermostatSettings *userSettings_ptr);


### PR DESCRIPTION
… pointer to the current schedule null. It now assigns the current schedule after downloading the new one